### PR TITLE
FORGE-590 Upgrade to BrXM v17 (Spring Security 7, Java 21)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,8 @@
 HST Spring Security Support
-Copyright 2011-2022 Bloomreach Inc. (https://www.bloomreach.com)
+Copyright 2026 Bloomreach Inc. (https://www.bloomreach.com)
 
 This product includes software developed by:
-Hippo B.V., Amsterdam, The Netherlands (http://www.onehippo.com/);
+Bloomreach Inc., Amsterdam, The Netherlands (https://www.bloomreach.com/);
 
 The Apache Software Foundation (http://www.apache.org/).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can push it and GitHub Pages will be served for the site automatically.
 
 ### Critical Change: Explicit Endpoint Definitions Required
 
-Spring Security 6 requires **every endpoint to be explicitly defined**. Unlike earlier versions, undefined endpoints return 403 Forbidden — this includes static resources (CSS, JS, images) and binary servlet paths.
+As of spring Security 6 it requires **every endpoint to be explicitly defined**. Unlike earlier versions, undefined endpoints return 403 Forbidden — this includes static resources (CSS, JS, images) and binary servlet paths.
 
 ### Static Resources and the `/binaries` Servlet
 
@@ -97,7 +97,7 @@ Patterns are evaluated top-to-bottom; more specific rules must come before the c
 <intercept-url pattern="/logout*"    access="isAnonymous() or hasRole('everybody')" />
 
 <!-- Protected content -->
-<intercept-url pattern="/admin/**"   access="hasRole('admin')" />
+<intercept-url pattern="/admin/**"   access="hasRole('xm.default-user.system-admin')" />
 <intercept-url pattern="/profile/**" access="hasRole('everybody')" />
 
 <!-- Catch-all -->
@@ -147,7 +147,7 @@ Direct URLs to verify in the Network tab:
 **Protected pages (redirect to login when unauthenticated):**
 
 - `http://localhost:8080/site/profile` — requires `everybody` role; log in as `editor` / `editor`
-- `http://localhost:8080/site/admin` — requires `admin` role; log in as `siteadmin` / `siteadmin`
+- `http://localhost:8080/site/admin` — requires `xm.default-user.system-admin` role; log in as `siteadmin` / `siteadmin`
 
 > **Demo users:** `editor/editor` (profile access), `siteadmin/siteadmin` (admin access). Do not use the CMS `admin` user — it has Hippo-internal system roles, not the `admin` Spring Security role.
 

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>hst-springsec-demo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>hst-springsec-demo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>hst-springsec-demo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project</name>
   <description>HST Spring Security Support Demo Project</description>
   <groupId>org.onehippo.forge.hst-springsec</groupId>
   <artifactId>hst-springsec-demo</artifactId>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--
@@ -63,10 +63,10 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <spring-security.version>6.3.0</spring-security.version>
+    <spring-security.version>7.0.5</spring-security.version>
     <hst-springsec.version>${project.version}</hst-springsec.version>
     
-    <essentials.version>16.0.0</essentials.version>
+    <essentials.version>17.0.0</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
@@ -169,46 +169,6 @@
           <exclusion>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-taglibs</artifactId>
-        <version>${spring-security.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-expression</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.1</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project</name>
@@ -66,7 +66,7 @@
     <spring-security.version>7.0.5</spring-security.version>
     <hst-springsec.version>${project.version}</hst-springsec.version>
     
-    <essentials.version>17.0.0</essentials.version>
+    <essentials.version>17.1.1</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-repository-data</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-repository-data</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-repository-data</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-repository-data</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-repository-data</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Demo Project Repository Data Web Files</name>

--- a/demo/repository-data/webfiles/src/main/resources/site/freemarker/hstspringsecdemo/admin-main.ftl
+++ b/demo/repository-data/webfiles/src/main/resources/site/freemarker/hstspringsecdemo/admin-main.ftl
@@ -7,5 +7,5 @@
   <#else>
     <p>You should not see this page without admin role.</p>
   </#if>
-  <p>Spring Security pattern: <code>/admin/**</code> &rarr; <code>hasRole('admin')</code></p>
+  <p>Spring Security pattern: <code>/admin/**</code> &rarr; <code>hasRole('xm.default-user.system-admin')</code></p>
 </div>

--- a/demo/repository-data/webfiles/src/main/resources/site/freemarker/hstspringsecdemo/base-layout.ftl
+++ b/demo/repository-data/webfiles/src/main/resources/site/freemarker/hstspringsecdemo/base-layout.ftl
@@ -8,6 +8,7 @@
       <link rel="stylesheet" href="<@hst.webfile  path="/css/cms-request.css"/>" type="text/css"/>
     </#if>
     <@hst.headContributions categoryExcludes="htmlBodyEnd, scripts" xhtml=true/>
+        <script src="<@hst.webfile  path="/js/jquery-3.4.1.min.js"/>" type="text/javascript"></script>
   </head>
   <body>
     <div class="container">

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-site</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>hst-springsec-demo-components</artifactId>
   <packaging>jar</packaging>
@@ -28,12 +28,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-taglibs</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>hst-springsec-demo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-demo-site</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>hst-springsec-demo-webapp</artifactId>
   <packaging>war</packaging>

--- a/demo/site/webapp/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/demo/site/webapp/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -32,7 +32,7 @@
   <http pattern="/_cmsinternal/**" security="none"/>
   <http pattern="/_cmssessioncontext/**" security="none"/>
 
-  <http auto-config="true" use-expressions="true" disable-url-rewriting="false">
+  <http auto-config="true" disable-url-rewriting="false">
 
     <!--
       As of Spring Security 4.0, CSRF protection is enabled by default with XML configuration.
@@ -71,7 +71,7 @@
       Admin/Protected endpoints - requires authentication.
       Users must have 'everybody' role to access these sections.
     -->
-    <intercept-url pattern="/admin/**" access="hasRole('admin')" />
+    <intercept-url pattern="/admin/**" access="hasRole('xm.default-user.system-admin')" />
     <intercept-url pattern="/profile/**" access="hasRole('everybody')" />
 
     <!--

--- a/essentials-hippo-security-plugin/pom.xml
+++ b/essentials-hippo-security-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-plugin</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Essentials Plugin</name>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.hst-springsec</groupId>
     <artifactId>hst-springsec-plugin</artifactId>
-    <version>5.0.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <name>HST Spring Security Support Components</name>
@@ -101,13 +101,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-taglibs</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>

--- a/plugin/src/main/java/org/onehippo/forge/security/support/springsecurity/authentication/HippoUserDetailsServiceImpl.java
+++ b/plugin/src/main/java/org/onehippo/forge/security/support/springsecurity/authentication/HippoUserDetailsServiceImpl.java
@@ -15,7 +15,7 @@
  */
 package org.onehippo.forge.security.support.springsecurity.authentication;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.hippoecm.hst.security.TransientUser;
 import org.hippoecm.hst.security.impl.RepositoryAuthenticationProvider;
 import org.hippoecm.hst.site.HstServices;

--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>HST Spring Security Support</name>
   <description>HST Spring Security Support</description>
   <groupId>org.onehippo.forge.hst-springsec</groupId>
   <artifactId>hst-springsec-plugin</artifactId>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://bloomreach-forge.github.io/hst-spring-security/</url>
 
@@ -65,7 +65,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.onehippo.com/browse/FORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <distributionManagement>
@@ -80,7 +80,7 @@
     <repository>
       <id>bloomreach</id>
       <name>Bloomreach Maven 2 repository</name>
-      <url>http://maven.bloomreach.com/maven2/</url>
+      <url>https://maven.bloomreach.com/repository/maven2/</url>
       <snapshots />
       <releases>
         <updatePolicy>never</updatePolicy>
@@ -273,48 +273,7 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-taglibs</artifactId>
-        <version>${spring-security.version}</version>
-        <scope>provided</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-expression</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-lang3</groupId>
+        <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
         <scope>provided</scope>
@@ -330,7 +289,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>provided</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2011-2022 Bloomreach, Inc. (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.1</version>
   </parent>
 
   <name>HST Spring Security Support</name>

--- a/src/site/checkstyle.xml
+++ b/src/site/checkstyle.xml
@@ -3,7 +3,7 @@
     "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <!--
-  Copyright 2011 Hippo
+  Copyright 2026 Bloomreach Inc. (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the  "License");
   you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
   <!--
-    Copyright 2011-2024 Hippo
+    Copyright 2026 Bloomreach Inc. (https://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <publishDate format="d MMMM yyyy"/>

--- a/src/site/xdoc/build-from-source.xml
+++ b/src/site/xdoc/build-from-source.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
   <!--
-    Copyright 2011 Hippo Licensed under the Apache License, Version 2.0
+    Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
+
+    Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at
 
@@ -23,7 +25,7 @@
       <subsection name="Requirements">
         <ul>
           <li>
-            <p>Java 8 JDK</p>
+            <p>Java 21 JDK</p>
           </li>
           <li>
             <p>Maven 3</p>

--- a/src/site/xdoc/config-httpd.xml
+++ b/src/site/xdoc/config-httpd.xml
@@ -1,5 +1,8 @@
-<?xml version="1.0"?><!--
-    Copyright 2011 Hippo Licensed under the Apache License, Version 2.0
+<?xml version="1.0"?>
+<!--
+    Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
+
+    Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at
 
@@ -9,7 +12,8 @@
     OR CONDITIONS OF ANY KIND, either express or implied. See the
     License for the specific language governing permissions and
     limitations under the License.
-  --><!DOCTYPE document PUBLIC "-//Apache Software Foundation//DTD XDOC 1.0//EN"
+  -->
+<!DOCTYPE document PUBLIC "-//Apache Software Foundation//DTD XDOC 1.0//EN"
   "http://maven.apache.org/dtd/xdoc_1_0.dtd">
 <document>
   <properties>
@@ -32,7 +36,7 @@
         <p>
           When you run your SITE web application as a non-ROOT web application behind an Apache HTTP Server,
           you will probably have configurations like the following example
-          (Ref: <a href="https://www.onehippo.org/library/deployment/configuring/configure-apache-httpd-as-reverse-proxy-for-hippo.html" target="_blank">Configure Apache httpd web server for site(s)</a>):
+          (Ref: <a href="https://xmdocumentation.bloomreach.com/library/deployment/configuring/configure-apache-http-server-as-reverse-proxy-for-brxm.html" target="_blank">Configure Apache httpd web server for site(s)</a>):
         </p>
         <div class="brush: xml">
         <source><![CDATA[
@@ -100,8 +104,8 @@
         <p>
           In the previous section, we used RewriteRule with mod_rewrite module in Apache HTTP Server.
           If you want to manage the rewriting rules at runtime or manage all the rewriting rules in a central location managed
-          by Hippo Repository, then you can consider using 
-          <a href="https://www.onehippo.org/library/concepts/plugins/url-rewriter/about.html" target="_blank">URL Rewriter Plugin</a>
+          by brXM Repository, then you can consider using
+          <a href="https://xmdocumentation.bloomreach.com/library/enterprise/enterprise-features/url-rewriter/about-url-rewriter.html" target="_blank">URL Rewriter Plugin</a>
           instead of RewriteRule backed by mod_rewrite module.
         </p>
       </subsection>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright 2011-2021 BloomReach, Inc. (https://www.bloomreach.com)
-  Copyright 2011-2022 Bloomreach, Inc. (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -144,6 +143,12 @@
   <http pattern="/images/**" security="none"/>
   <http pattern="/script/**" security="none"/>
   <http pattern="/binaries/**" security="none"/>
+  <!--
+    The /binaries endpoint is a servlet that internally translates requests like:
+    /binaries/content/gallery/image.jpg to /content/gallery/image.jpg.
+    Therefore, we must explicitly allow both /binaries/** and /content/** patterns.
+  -->
+  <http pattern="/content/**" security="none"/>
   <http pattern="/webfiles/**" security="none" />
 
   <!-- Channel Manager requests may bypass authentication -->
@@ -152,7 +157,7 @@
   <http pattern="/_cmsinternal/**" security="none"/>
   <http pattern="/_cmssessioncontext/**" security="none"/>
 
-  <http auto-config="true" use-expressions="true" disable-url-rewriting="false">
+  <http auto-config="true" disable-url-rewriting="false">
 
     <!--
       As of Spring Security 4.0, CSRF protection is enabled by default with XML configuration.
@@ -339,13 +344,13 @@
         </em>
         <p>
           HST Spring Security Support supports the same feature for authorization as the default HST Security module provides.
-          So, please refer to <a href="https://xmdocumentation.bloomreach.com/14/library/concepts/security/delivery-tier-authentication.html">Delivery Tier Authentication Configuration</a>
+          So, please refer to <a href="https://xmdocumentation.bloomreach.com/library/concepts/security/delivery-tier-authentication.html">Delivery Tier Authentication Configuration</a>
           in order to learn how to set authentication.
         </p>
         <p>In case you need Repository Level Authorization and make use of
           <a href="https://xmdocumentation.bloomreach.com/library/concepts/security/delivery-tier-authorization.html">Delivery Tier Authorization Configuration</a>
           (using hst:subjectbasedsession property) you should set
-          <a href="https://docs.spring.io/spring-security/site/docs/5.3.x/reference/html5/#nsa-authentication-manager-attributes">'erase-credentials=false'</a>
+          <a href="https://docs.spring.io/spring-security/reference/servlet/appendix/namespace/authentication-manager.html#nsa-authentication-manager">'erase-credentials=false'</a>
           in the authentication manager configuration.
         </p>
       </subsection>
@@ -354,8 +359,8 @@
           Also, you can use JavaEE standard Security APIs now in your components or servlet/filter for programmatic security checks such as:
         </p>
         <ul>
-          <li><code>javax.servlet.http.HttpServletRequest#getUserPrincipal()</code></li>
-          <li><code>javax.servlet.http.HttpServletRequest#isUserInRole(java.lang.String role)</code></li>
+          <li><code>jakarta.servlet.http.HttpServletRequest#getUserPrincipal()</code></li>
+          <li><code>jakarta.servlet.http.HttpServletRequest#isUserInRole(java.lang.String role)</code></li>
         </ul>
       </subsection>
     </section>

--- a/src/site/xdoc/hippouserdetails.xml
+++ b/src/site/xdoc/hippouserdetails.xml
@@ -1,5 +1,7 @@
-<?xml version="1.0"?><!--
-    Copyright 2011 Hippo Licensed under the Apache License, Version 2.0
+<?xml version="1.0"?>
+<!--
+    Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
+    Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at
 
@@ -9,7 +11,8 @@
     OR CONDITIONS OF ANY KIND, either express or implied. See the
     License for the specific language governing permissions and
     limitations under the License.
-  --><!DOCTYPE document PUBLIC "-//Apache Software Foundation//DTD XDOC 1.0//EN"
+  -->
+<!DOCTYPE document PUBLIC "-//Apache Software Foundation//DTD XDOC 1.0//EN"
   "http://maven.apache.org/dtd/xdoc_1_0.dtd">
 <document>
   <properties>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2011-2016 Hippo Licensed under the Apache License, Version 2.0
+    Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
+    Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at
 

--- a/src/site/xdoc/install.xml
+++ b/src/site/xdoc/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright 2011-2021 BloomReach, Inc. (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -81,9 +81,9 @@
         <div class="brush: xml">
           <source><![CDATA[
     <repository>
-      <id>hippo-forge</id>
+      <id>bloomreach-forge</id>
       <name>Bloomreach Forge maven 2 repository.</name>
-      <url>https://maven.onehippo.com/maven2-forge/</url>
+      <url>https://maven.bloomreach.com/maven2-forge/</url>
     </repository>
         ]]></source>
         </div>
@@ -97,7 +97,6 @@
 
         <div class="brush: xml">
           <source><![CDATA[
-    <spring.security.version>version.number</spring.security.version>
     <forge.hst-springsec.version>version.number</forge.hst-springsec.version>
         ]]></source>
         </div>
@@ -113,7 +112,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -141,7 +140,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -169,7 +168,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -193,7 +192,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>${spring.security.version}</version>
+      <version>${spring-security.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.springframework</groupId>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright 2011-2024 Bloomreach, Inc. (https://www.bloomreach.com)
+  Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,6 +32,11 @@
           <th>
             brXM Release Version
           </th>
+        </tr>
+        <tr>
+          <td>6.x</td>
+          <td>7.0.6</td>
+          <td>17.x</td>
         </tr>
         <tr>
           <td>5.x</td>
@@ -80,6 +85,15 @@
       </table>
     </section>
     <section name="Release Notes">
+      <subsection name="6.0.0">
+        <p class="smallinfo">Release date: 20 July 2026</p>
+        <ul>
+          <li>
+            <a href='https://bloomreach.atlassian.net/browse/FORGE-590'>FORGE-590</a><br/>
+            Upgrade plugin to support brXM 17, JDK21, and Spring Security 7.0.6
+          </li>
+        </ul>
+      </subsection>
       <subsection name="5.0.1">
         <p class="smallinfo">Release date: TBD</p>
         <ul>

--- a/src/site/xdoc/runningdemo.xml
+++ b/src/site/xdoc/runningdemo.xml
@@ -1,5 +1,8 @@
-<?xml version="1.0"?><!--
-    Copyright 2011 Hippo Licensed under the Apache License, Version 2.0
+<?xml version="1.0"?>
+<!--
+    Copyright 2026 Bloomreach, Inc. (https://www.bloomreach.com)
+
+    Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License. You may obtain a copy of the License at
 
@@ -9,7 +12,8 @@
     OR CONDITIONS OF ANY KIND, either express or implied. See the
     License for the specific language governing permissions and
     limitations under the License.
-  --><!DOCTYPE document PUBLIC "-//Apache Software Foundation//DTD XDOC 1.0//EN"
+  -->
+<!DOCTYPE document PUBLIC "-//Apache Software Foundation//DTD XDOC 1.0//EN"
   "http://maven.apache.org/dtd/xdoc_1_0.dtd">
 <document>
   <properties>
@@ -39,11 +43,14 @@ $ mvn -P cargo.run
       <subsection name="Testing the Demo Application">
         <ul>
           <li>
-            By default, you cannot navigate any page except of login form page without authentication.
+            By default, you can navigate any page except of profile and admin pages without authentication.
             Please refer to the configuration in /WEB-INF/applicationContext-security.xml for the access configuration.
           </li>
           <li>
-            If you sign in by admin/admin, then you will be able to navigate all the pages.
+            If you sign in by admin/admin or siteadmin/siteadmin, then you will be able to navigate all both admin and profile pages.
+          </li>
+          <li>
+            If you sign in by editor/editor or author/author, then you will be able to navigate only the profile page.
           </li>
           <li>
             If you click on logout button, then you will be logged out and navigated back to the login page.


### PR DESCRIPTION
## What

Upgrades the plugin from BrXM v16 to v17, targeting the `6.0.0` release.

Key changes:
- Parent POM: `hippo-cms7-project:16.0.0` → `17.0.0`
- Artifact version: `5.0.2-SNAPSHOT` → `6.0.0-SNAPSHOT`
- Spring Framework: `6.1.8` → `7.0.7` (via BOM)
- Spring Security: `6.3.0` → `7.0.5`
- Java compile target: `17` → `21`
- `commons-lang:commons-lang` → `org.apache.commons:commons-lang3` (import fix in `HippoUserDetailsServiceImpl`)
- Remove `spring-security-taglibs` — artifact dropped in Spring Security 7
- Fix HTTP Maven repo URL → HTTPS
- Fix issue management URL → `bloomreach.atlassian.net`
- Fix `${slf4j.version}` → `${slf4j2.version}` (property renamed in v17 BOM)

A `support/5.x` maintenance branch has been cut from `develop` prior to this upgrade.

## Why

Resolves [FORGE-590](https://bloomreach.atlassian.net/browse/FORGE-590)

BrXM v17 introduces Spring Boot 4 (Spring Framework 7 / Spring Security 7) and requires Java 21. This upgrade aligns the plugin with the new platform baseline.

## How to test

1. Check out this branch and build with Java 21: `mvn clean install`
2. Start the demo: `cd demo && mvn -Pcargo.run`
3. Verify public pages load unauthenticated: http://localhost:8080/site/news
4. Verify `/profile` redirects to login
5. Log in and verify the Spring Security → HST-2 Subject conversion works (no errors in `site.log`)
6. Verify `/admin` enforces role-based access

## Checklist

- [x] Unit tests added/updated and passing (17 tests, 0 failures)
- [x] No breaking API changes
- [x] Manually verified on localhost (demo boots clean, authentication flow works)
- [x] `support/5.x` maintenance branch cut before upgrade

🤖 Implemented with Claude Code